### PR TITLE
「第～回」の文字列を話数の解析対象とする.

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -336,7 +336,7 @@ function convertPrograms(p, ch) {
 			.replace(/\[.\]/g, '')
 			.replace(/([^場版])「.+」/g, '$1')
 			.replace(/(#|＃|♯)[0-9０１２３４５６７８９]+/g, '')
-			.replace(/第([0-9]+|[０１２３４５６７８９零一壱二弐三参四五伍六七八九十拾]+)話/g, '')
+			.replace(/第([0-9]+|[０１２３４５６７８９零一壱二弐三参四五伍六七八九十拾]+)(?:話|回)/g, '')
 			.replace(/([0-9]+|[０１２３４５６７８９]+)品目/g, '')
 			.trim();
 		
@@ -361,7 +361,7 @@ function convertPrograms(p, ch) {
 		if (flags.indexOf('新') !== -1) {
 			episodeNumber = 1;
 		} else {
-			var episodeNumberMatch = (c.title[0]._ + desc).match(/((#|＃|♯)[0-9０１２３４５６７８９]+|第([0-9]+|[０１２３４５６７８９零一二三四五六七八九十]+)話)|([0-9]+|[０１２３４５６７８９]+)品目|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
+			var episodeNumberMatch = (c.title[0]._ + desc).match(/((#|＃|♯)[0-9０１２３４５６７８９]+|第([0-9]+|[０１２３４５６７８９零一二三四五六七八九十]+)(?:話|回))|([0-9]+|[０１２３４５６７８９]+)品目|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
 			if (episodeNumberMatch !== null) {
 				var episodeNumberString = episodeNumberMatch[0];
 				
@@ -371,6 +371,7 @@ function convertPrograms(p, ch) {
 					.replace('♯', '')
 					.replace('第', '')
 					.replace('話', '')
+					.replace('回', '')
 					.replace('喪', '')
 					.replace('品目', '')
 					.replace('Ｅｐｉｓｏｄｅ', '')


### PR DESCRIPTION
番組詳細情報(xmltvフォーマット上のdesc)の「第～回」がepisodeNumberの解析対象となっていないため、
話数を認識できない番組があります。
(e.g. ハピネスチャージプリキュア！)