### PR TITLE
add zero-pad feature for episode numbering

### DIFF
--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -260,6 +260,13 @@ exports.formatRecordedName = function (program, name) {
 		// subtitle
 		if (a.match(/^subtitle$/) !== null) { return exports.stripFilename(program.subTitle || ''); }
 		
+		// episode (zero-padded)
+		if (a.match(/^episode:\d+$/) !== null) { return (function(e, l){
+			if (isNaN(l)) { l = 1; }
+			e = e.toString();
+			return e.length >= l ? e : new Array(l - e.length + 1).join('0') + e;
+		})(program.episode, a.match(/\d+/)[0]) || 'n'; }
+
 		// episode
 		if (a.match(/^episode$/) !== null) { return program.episode || 'n'; }
 		


### PR DESCRIPTION
録画ファイル名の話数に対してzero-pad(桁揃え)する機能を実装しました。
config.jsonの`recordedFormat`に`<episode:桁幅>`のように書くことで、話数を任意の桁数に揃えることができます。
従来の`<episode>`表記とも互換性があります。

例: 
`{fullTitle: "ユリ熊嵐", episode: "5"}`に対して、
`recordedFormat = "<title> <episode>.m2ts"`の場合のファイル名: `ユリ熊嵐 5.m2ts` (従来のネーミング)
`recordedFormat = "<title> <episode:2>.m2ts"`の場合のファイル名: `ユリ熊嵐 05.m2ts`