### PR TITLE
Installer: fix a specification of png encoder related option

### DIFF
--- a/chinachu
+++ b/chinachu
@@ -396,6 +396,7 @@ chinachu_installer_libav () {
     --enable-libvpx \
     --enable-libfdk-aac \
     --enable-libvorbis \
+    --enable-zlib \
     --disable-debug \
     --disable-decoders \
     --disable-encoders \


### PR DESCRIPTION
APIで`api/recorded/:id/preview.png`のレスポンスが空だったのでログを見てみたところ、下記添付1の出力がありました。
`./chinachu installer`で1を与えた時にインストールされたavconvのコーデックを調べてみたところ、添付2のようにpngのエンコーダーが有効になっていませんでした。
travisCIの`echo 1 | ./chinachu installer`実行時のlibavの`./configure`による出力を見ても__Enabled encoders:__の項にpngはありません。
パラメーターの不具合を疑い、configureを眺めているとautodetectとなっているpngエンコーダーに必須のzlibが、諸々の--disable-**パラメーターによって無効化されてしまい、組み込まれなかったようです。
その点修正しました。
こちらの環境固有の問題かもしれないので、他の環境で発生しない場合はリジェクトしてください。

## 添付1　log/wui
```
18 Feb 16:20:46 - { [Error: Command failed: /bin/sh -c avconv -f mpegts -ss 3.5 -r 10 -i "./recorded2/[150217-0030][GR15][PT3-T2]ユリ熊嵐.m2ts" -ss 1.5 -r 10 -frames:v 1 -c:v png -an -f image2 -s 320x180 -map 0:0 -y pipe:1
avconv version 10.5, Copyright (c) 2000-2014 the Libav developers
  built on Feb 18 2015 15:57:47 with gcc 4.7 (Debian 4.7.2-5)
[aac @ 0x15a62c0] get_buffer() failed
[mpeg2video @ 0x15a5940] Invalid frame dimensions 0x0.
    Last message repeated 2 times
[NULL @ 0x15a6b40] start time is not set in estimate_timings_from_pts
[NULL @ 0x15a74a0] start time is not set in estimate_timings_from_pts
[NULL @ 0x15a7d20] start time is not set in estimate_timings_from_pts
[NULL @ 0x15a8680] start time is not set in estimate_timings_from_pts
[NULL @ 0x15a8f00] start time is not set in estimate_timings_from_pts
[NULL @ 0x15a9860] start time is not set in estimate_timings_from_pts
[NULL @ 0x15aa0e0] start time is not set in estimate_timings_from_pts
[NULL @ 0x15aaaa0] start time is not set in estimate_timings_from_pts
[NULL @ 0x15ab420] start time is not set in estimate_timings_from_pts
[mpegts @ 0x15898c0] PES packet size mismatch
Input #0, mpegts, from './recorded2/[150217-0030][GR15][PT3-T2]ã<U+0083>¦ã<U+0083>ªç<U+0086><U+008A>åµ<U+0090>.m2ts':
  Duration: 00:29:56.21, start: 13858.939133, bitrate: 8455 kb/s
  Program 23608
    Stream #0.0[0x111]: Video: mpeg2video (Main), yuv420p, 1440x1080 [PAR 4:3 DAR 16:9], 20000 kb/s, 29.97 fps, 90k tbn, 59.94 tbc
    Stream #0.1[0x112]: Audio: aac, 48000 Hz, stereo, fltp, 242 kb/s
    Stream #0.2[0x740]: Data: [13][0][0][0] / 0x000D
    Stream #0.3[0x750]: Data: [13][0][0][0] / 0x000D
    Stream #0.4[0x751]: Data: [13][0][0][0] / 0x000D
    Stream #0.5[0x752]: Data: [13][0][0][0] / 0x000D
    Stream #0.6[0x960]: Data: [13][0][0][0] / 0x000D
    Stream #0.7[0x961]: Data: [13][0][0][0] / 0x000D
    Stream #0.8[0x75e]: Data: [13][0][0][0] / 0x000D
    Stream #0.9[0x75f]: Data: [13][0][0][0] / 0x000D
    Stream #0.10[0x96e]: Data: [13][0][0][0] / 0x000D
Unknown encoder 'png'
]
  killed: false,
  code: 1,
  signal: null,
  cmd: '/bin/sh -c avconv -f mpegts -ss 3.5 -r 10 -i "./recorded2/[150217-0030][GR15][PT3-T2]ユリ熊嵐.m2ts" -ss 1.5 -r 10 -frames:v 1 -c:v png -an -f image2 -s 320x180 -map 0:0 -y pipe:1' }
18 Feb 16:20:46 - 200(!503) GET:/api/recorded/gr23608-1dnh/preview.png ::ffff:192.168.0.244 Safari/537.36
```


## 添付2　avconvのコーデック情報
```
$ ./Chinachu/usr/bin/avconv -codecs | grep png
avconv version 10.5, Copyright (c) 2000-2014 the Libav developers
  built on Feb 18 2015 15:57:47 with gcc 4.7 (Debian 4.7.2-5)
..V..S png                  PNG (Portable Network Graphics) image
```