### PR TITLE
ルールごとに個別のrecordedFormatを指定する機能を追加

### DIFF
--- a/app-operator.js
+++ b/app-operator.js
@@ -252,7 +252,7 @@ function doRecord(program) {
 	program.tuner = tuner;
 	
 	// 保存先パス
-	recPath = config.recordedDir + chinachu.formatRecordedName(program, config.recordedFormat);
+	recPath = config.recordedDir + chinachu.formatRecordedName(program, program.recordedFormat || config.recordedFormat);
 	program.recorded = recPath;
 	
 	// 保存先ディレクトリ

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -320,6 +320,15 @@ function scheduler() {
 		}
 	}
 	
+	// ruleにもしあればreserveにrecordedFormatを追加
+	reserves.forEach(function(reserve){
+		rules.forEach(function(rule){
+			if(typeof(rule.recorded_format) !== 'undefined' && chinachu.programMatchesRule(rule, reserve)){
+				reserve.recordedFormat = rule.recorded_format;
+			}
+		});
+	});
+	
 	// results
 	util.log('MATCHES: ' + matches.length.toString(10));
 	util.log('DUPLICATES: ' + duplicateCount.toString(10));

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -279,146 +279,150 @@ exports.stripFilename = function (a) {
 	return a;
 };
 
+// 全ルールとのマッチ判定
 exports.isMatchedProgram = function (rules, program) {
-	var result = false;
-	
-	rules.forEach(function (rule) {
-		
-		var i, j, l, m, isFound;
-		
-		// isDisabled
-		if (rule.isDisabled) { return; }
-		
-		// sid
-		if (rule.sid && rule.sid !== program.channel.sid) { return; }
-		
-		// types
-		if (rule.types) {
-			if (rule.types.indexOf(program.channel.type) === -1) { return; }
+	for(var i = 0; i < rules.length; i++){
+		if(exports.programMatchesRule(rules[i], program)){
+			return true;
 		}
-		
-		// channels
-		if (rule.channels) {
-			if (rule.channels.indexOf(program.channel.id) === -1) {
-				if (rule.channels.indexOf(program.channel.channel) === -1) {
-					return;
-				}
-			}
-		}
-		
-		// ignore_channels
-		if (rule.ignore_channels) {
-			if (rule.ignore_channels.indexOf(program.channel.id) !== -1) {
-				return;
-			}
-			if (rule.ignore_channels.indexOf(program.channel.channel) !== -1) {
-				return;
-			}
-		}
-		
-		// category
-		if (rule.category && rule.category !== program.category) { return; }
-		
-		// categories
-		if (rule.categories) {
-			if (rule.categories.indexOf(program.category) === -1) { return; }
-		}
-		
-		// hour
-		if (rule.hour && (typeof rule.hour.start !== 'undefined') && (typeof rule.hour.end !== 'undefined')) {
-			var ruleStart = rule.hour.start;
-			var ruleEnd   = rule.hour.end;
-			
-			var progStart = new Date(program.start).getHours();
-			var progEnd   = new Date(program.end).getHours();
-			var progEndMinute = new Date(program.end).getMinutes();
-			
-			if (progStart > progEnd) {
-				progEnd += 24;
-			}
-			if (progEndMinute === 0 ) {
-				progEnd -= 1;
-			}
-			
-			if (ruleStart > ruleEnd) {
-				if ((ruleStart > progStart) && (ruleEnd < progEnd)) { return; }
-			} else {
-				if ((ruleStart > progStart) || (ruleEnd < progEnd)) { return; }
-			}
-		}
-		
-		// duration
-		if (rule.duration && (typeof rule.duration.min !== 'undefined') && (typeof rule.duration.max !== 'undefined')) {
-			if ((rule.duration.min > program.seconds) || (rule.duration.max < program.seconds)) { return; }
-		}
-		
-		// reserve_titles
-		if (rule.reserve_titles) {
-			isFound = false;
-			
-			for (i = 0; i < rule.reserve_titles.length; i++) {
-				if (program.fullTitle.match(rule.reserve_titles[i]) !== null) { isFound = true; }
-			}
-			
-			if (!isFound) { return; }
-		}
-		
-		// ignore_titles
-		if (rule.ignore_titles) {
-			for (i = 0; i < rule.ignore_titles.length; i++) {
-				if (program.fullTitle.match(rule.ignore_titles[i]) !== null) { return; }
-			}
-		}
-		
-		// reserve_descriptions
-		if (rule.reserve_descriptions) {
-			if (!program.detail) { return; }
-			
-			isFound = false;
-			
-			for (i = 0; i < rule.reserve_descriptions.length; i++) {
-				if (program.detail.match(rule.reserve_descriptions[i]) !== null) { isFound = true; }
-			}
-			
-			if (!isFound) { return; }
-		}
-		
-		// ignore_descriptions
-		if (rule.ignore_descriptions) {
-			if (!program.detail) { return; }
-			
-			for (i = 0; i < rule.ignore_descriptions.length; i++) {
-				if (program.detail.match(rule.ignore_descriptions[i]) !== null) { return; }
-			}
-		}
-		
-		// ignore_flags
-		if (rule.ignore_flags) {
-			for (i = 0; i < rule.ignore_flags.length; i++) {
-				for (j = 0; j < program.flags.length; j++) {
-					if (rule.ignore_flags[i] === program.flags[j]) { return; }
-				}
-			}
-		}
-		
-		// reserve_flags
-		if (rule.reserve_flags) {
-			if (!program.flags) { return; }
-			
-			isFound = false;
-			
-			for (i = 0; i < rule.reserve_flags.length; i++) {
-				for (j = 0; j < program.flags.length; j++) {
-					if (rule.reserve_flags[i] === program.flags[j]) { isFound = true; }
-				}
-			}
-			
-			if (!isFound) { return; }
-		}
-		
-		result = true;
-		
-	});
-	
-	return result;
+	}
+
+	return false;
 };
+
+// 単体のルールとのマッチ判定
+exports.programMatchesRule = function (rule, program) {
+	var i, j, l, m, isFound;
+
+	// isDisabled
+	if (rule.isDisabled) { return false; }
+
+	// sid
+	if (rule.sid && rule.sid !== program.channel.sid) { return false; }
+
+	// types
+	if (rule.types) {
+		if (rule.types.indexOf(program.channel.type) === -1) { return false; }
+	}
+
+	// channels
+	if (rule.channels) {
+		if (rule.channels.indexOf(program.channel.id) === -1) {
+			if (rule.channels.indexOf(program.channel.channel) === -1) {
+				return false;
+			}
+		}
+	}
+
+	// ignore_channels
+	if (rule.ignore_channels) {
+		if (rule.ignore_channels.indexOf(program.channel.id) !== -1) {
+			return false;
+		}
+		if (rule.ignore_channels.indexOf(program.channel.channel) !== -1) {
+			return false;
+		}
+	}
+
+	// category
+	if (rule.category && rule.category !== program.category) { return false; }
+
+	// categories
+	if (rule.categories) {
+		if (rule.categories.indexOf(program.category) === -1) { return false; }
+	}
+
+	// hour
+	if (rule.hour && (typeof rule.hour.start !== 'undefined') && (typeof rule.hour.end !== 'undefined')) {
+		var ruleStart = rule.hour.start;
+		var ruleEnd   = rule.hour.end;
+
+		var progStart = new Date(program.start).getHours();
+		var progEnd   = new Date(program.end).getHours();
+		var progEndMinute = new Date(program.end).getMinutes();
+
+		if (progStart > progEnd) {
+			progEnd += 24;
+		}
+		if (progEndMinute === 0 ) {
+			progEnd -= 1;
+		}
+
+		if (ruleStart > ruleEnd) {
+			if ((ruleStart > progStart) && (ruleEnd < progEnd)) { return false; }
+		} else {
+			if ((ruleStart > progStart) || (ruleEnd < progEnd)) { return false; }
+		}
+	}
+
+	// duration
+	if (rule.duration && (typeof rule.duration.min !== 'undefined') && (typeof rule.duration.max !== 'undefined')) {
+		if ((rule.duration.min > program.seconds) || (rule.duration.max < program.seconds)) { return false; }
+	}
+
+	// reserve_titles
+	if (rule.reserve_titles) {
+		isFound = false;
+
+		for (i = 0; i < rule.reserve_titles.length; i++) {
+			if (program.fullTitle.match(rule.reserve_titles[i]) !== null) { isFound = true; }
+		}
+
+		if (!isFound) { return false; }
+	}
+
+	// ignore_titles
+	if (rule.ignore_titles) {
+		for (i = 0; i < rule.ignore_titles.length; i++) {
+			if (program.fullTitle.match(rule.ignore_titles[i]) !== null) { return false; }
+		}
+	}
+
+	// reserve_descriptions
+	if (rule.reserve_descriptions) {
+		if (!program.detail) { return false; }
+
+		isFound = false;
+
+		for (i = 0; i < rule.reserve_descriptions.length; i++) {
+			if (program.detail.match(rule.reserve_descriptions[i]) !== null) { isFound = true; }
+		}
+
+		if (!isFound) { return false; }
+	}
+
+	// ignore_descriptions
+	if (rule.ignore_descriptions) {
+		if (!program.detail) { return false; }
+
+		for (i = 0; i < rule.ignore_descriptions.length; i++) {
+			if (program.detail.match(rule.ignore_descriptions[i]) !== null) { return false; }
+		}
+	}
+
+	// ignore_flags
+	if (rule.ignore_flags) {
+		for (i = 0; i < rule.ignore_flags.length; i++) {
+			for (j = 0; j < program.flags.length; j++) {
+				if (rule.ignore_flags[i] === program.flags[j]) { return false; }
+			}
+		}
+	}
+
+	// reserve_flags
+	if (rule.reserve_flags) {
+		if (!program.flags) { return false; }
+
+		isFound = false;
+
+		for (i = 0; i < rule.reserve_flags.length; i++) {
+			for (j = 0; j < program.flags.length; j++) {
+				if (rule.reserve_flags[i] === program.flags[j]) { isFound = true; }
+			}
+		}
+
+		if (!isFound) { return false; }
+	}
+
+	return true;
+}

--- a/web/class.js
+++ b/web/class.js
@@ -1283,6 +1283,15 @@
 									}
 								},
 								{
+									key	: 'recorded_format',
+									label	: '録画ファイル名フォーマット',
+									input	: {
+										type	: 'text',
+										style	: { width: '100%' },
+										val	: rule.recorded_format
+									}
+								},
+								{
 									key   : 'isEnabled',
 									label : 'ルールの状態',
 									input : {
@@ -1506,6 +1515,14 @@
 							input : {
 								type : formInputTypeStrings,
 								style: { width: '100%' }
+							}
+						},
+						{
+							key	: 'recorded_format',
+							label	: '録画ファイル名フォーマット',
+							input	: {
+								type	: 'text',
+								style	: { width: '100%' },
 							}
 						},
 						{
@@ -1735,6 +1752,14 @@
 							input : {
 								type : formInputTypeStrings,
 								style: { width: '100%' }
+							}
+						},
+						{
+							key	: 'recorded_format',
+							label	: '録画ファイル名フォーマット',
+							input	: {
+								type	: 'text',
+								style	: { width: '100%' },
 							}
 						},
 						{

--- a/web/page/rules/list.js
+++ b/web/page/rules/list.js
@@ -245,6 +245,10 @@ P = Class.create(P, {
 				{
 					key  : 'ignore_descriptions',
 					label: '無視説明文'
+				},
+				{
+					key  : 'recorded_format',
+					label: '録画ファイル名フォーマット'
 				}
 			],
 			onSelect  : this.updateToolbar.bind(this),
@@ -436,6 +440,19 @@ P = Class.create(P, {
 					className: 'default',
 					sortKey  : 0,
 					text     : 'none'
+				};
+			}
+
+			if (rule.recorded_format) {
+				row.cell.recorded_format = {
+					text       : rule.recorded_format,
+					attribute  : { title: rule.recorded_format.truncate(256) }
+				};
+			} else {
+				row.cell.recorded_format = {
+					className: 'default',
+					sortKey  : 0,
+					text     : 'default'
 				};
 			}
 			


### PR DESCRIPTION
全ての番組に対してrecordedFormatが共通だとファイルの管理上厳しくなると思ったので、ルール(=シリーズ)毎に個別のrecordedFormatを指定できるようにしました。
シリーズ名、話数などを取得するのが難しい番組やそれらを独自に設定したい場合(全角/半角を統一したいなど)に役立つと思います。

##### 問題:
`recordedFormat = "<title> [<date:yymmdd-HHMM>] [<episode>].m2ts"`の場合

`ユリ熊嵐 [150210-0030] [6].m2ts` これは良い
﻿﻿`仮面ライダードライブ [150215-0800] [n].m2ts` 話数が取得できていないので'n'が入る
`Ｇｏ！プリンセスプリキュア　もうさよなら？パフを飼ってはいけません！ [150215-0830] [n].m2ts` サブタイトルまで入る + 話数が'n'

##### 解決策:
これに対して、`仮面ライダードライブ`、`Go!プリンセスプリキュア`についてそれぞれ
`仮面ライダードライブ [<date:yymmdd-HHMM>].m2ts`
`Go!プリンセスプリキュア [<date:yymmdd-HHMM>].m2ts`
のように個別に指定することで
`仮面ライダードライブ [150215-0800].m2ts`
`Go!プリンセスプリキュア [150215-0830].m2ts`
のようなファイル名が得られます。