### PR TITLE
Improve regular expression for anime title

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -365,7 +365,7 @@ function convertPrograms(p, ch) {
 			.replace(/第([0-9]+|[０１２３４５６７８９零一壱二弐三参四五伍六七八九十拾]+)(話|回)/g, '');
 		
 		if (c.category[1]._ === 'anime') {
-			title = title.replace(/アニメ「([^「」]+)」/g, '$1');
+			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1');
 		}
 		
 		title = title.trim();


### PR DESCRIPTION
アニメのタイトルが「TVアニメ」で始まる際に「TV」部分が残ってしまう件の修正です。
例：
修正前：TVアニメ「Fate/stay night」 → TVFate/stay night
修正後：TVアニメ「Fate/stay night」 → Fate/stay night