### PR TITLE
WUI/Client: リバースプロキシ使用時の不具合を修正

### DIFF
--- a/web/chinachu.js
+++ b/web/chinachu.js
@@ -32,7 +32,8 @@
 	};
 	
 	app.socket = io.connect(window.location.protocol + '//' + window.location.host, {
-		connectTimeout: 3000
+		connectTimeout: 3000,
+		resource: window.location.pathname.replace(/^\/|[^\/]*$/g, '') + 'socket.io',
 	});
 	
 	// コントロールビュー初期化


### PR DESCRIPTION
リバースプロキシ使用時、ルート以外のパスに設定しても、ルート直下(/socket.io)に接続される問題を修正しました。
#114 の対応だけでは動作しませんでした。