### PR TITLE
API: reject empty rule post and put

### DIFF
--- a/api/script-rules-rule.vm.js
+++ b/api/script-rules-rule.vm.js
@@ -11,9 +11,12 @@
 			return;
 		
 		case 'PUT':
-			if (request.headers['content-type'].match(/^application\/json/)) {
-				var newRule = request.query;
-				
+			var newRule = request.query;
+			if (request.headers['content-type'].match(/^application\/json/) === null) {
+				response.error(400);
+			} else if (JSON.stringify(newRule) === '{}') {
+				response.error(400);
+			} else {
 				if (newRule.isEnabled === false) {
 					newRule.isDisabled = true;
 				}
@@ -24,8 +27,6 @@
 				
 				response.head(200);
 				response.end(JSON.stringify(newRule));
-			} else {
-				response.error(400);
 			}
 			return;
 		

--- a/api/script-rules.vm.js
+++ b/api/script-rules.vm.js
@@ -7,9 +7,12 @@
 			return;
 		
 		case 'POST':
-			if (request.headers['content-type'].match(/^application\/json/)) {
-				var newRule = request.query;
-				
+			var newRule = request.query;
+			if (request.headers['content-type'].match(/^application\/json/) === null) {
+				response.error(400);
+			} else if (JSON.stringify(newRule) === '{}') {
+				response.error(400);
+			} else {
 				if (newRule.isEnabled === false) {
 					newRule.isDisabled = true;
 				}
@@ -20,8 +23,6 @@
 				
 				response.head(201);
 				response.end(JSON.stringify(newRule));
-			} else {
-				response.error(400);
 			}
 			return;
 	}


### PR DESCRIPTION
`/api/rules.json`に空のPOSTを送ると空のオブジェクトがルールに追加されますが、このルールはCLIが削除することができません(削除するには一旦何か条件を追加する必要があります)。

これを回避するためにPOSTの内容が空の場合は400エラーを返すようにしました。

### 再現方法
例えば以下のコードで空のルールを作成することができます。
```
curl http://192.168.x.y:zzzzz/api/rules.json -X POST -H 'content-type:application/json'
```
このルールがN番目に作成されたとすると、これを削除する以下のコードは500エラーとなります(`-w '%{http_code}\n'`を追加することによりステータスコードを確認できます)。
```
curl http://192.168.x.y:zzzzz/api/rules/N.json -X DELETE
```
以下のように一旦条件を追加することにより削除できます。
```
curl http://192.168.x.y:zzzzz/api/rules/N.json -X PUT -H 'content-type:application/json' -d '{"reserve_titles":["foo"]}'
curl http://192.168.x.y:zzzzz/api/rules/N.json -X DELETE
```
### 追記
PUTでも同じようなことができました。
```
curl http://192.168.x.y:zzzzz/api/rules/N.json -X PUT -H 'content-type:application/json'
```
