### PR TITLE
APIへアクセスしたログがlog/wuiに記載されない問題の修正

### DIFF
--- a/app-wui.js
+++ b/app-wui.js
@@ -599,17 +599,6 @@ function httpServerMain(req, res, query) {
 				}
 			};
 			
-			var onClose = function () {
-				
-				if (!isClosed) {
-					isClosed = true;
-					
-					log(res.statusCode);
-				}
-				
-				cleanup();
-			};
-			
 			var onResponseClose = function () {
 				
 				if (!isClosed) {
@@ -638,14 +627,14 @@ function httpServerMain(req, res, query) {
 					sandbox = null;
 				}, 1000);
 				
-				req.removeListener('close', onClose);
 				res.removeListener('close', onResponseClose);
+				res.removeListener('finish', onResponseClose);
 				
 				cleanup = emptyFunction;
 			};
 			
-			req.on('close', onClose);
 			res.on('close', onResponseClose);
+			res.on('finish', onResponseClose);
 			
 			try {
 				vm.runInNewContext(fs.readFileSync(scriptFile), sandbox, scriptFile);


### PR DESCRIPTION
いつの日からか自環境・でもサーバー共に、log/wuiにAPIのアクセスログが記載されなくなってしまっていたのでnodejsのドキュメントを追ったところ、
http.responseのfinishイベント発火にてコネクション終了通知になっていたのでそのように修正しました。
従来のresponseのcloseイベントはレスポンスが返し終わる前に接続が終了された場合に発火するようなので、その部分は残し、
requestのcloseイベントは発火しないようなので消しました。
