### PR TITLE
Set high priority for recording

### DIFF
--- a/api/script-channel-watch.vm.js
+++ b/api/script-channel-watch.vm.js
@@ -127,7 +127,7 @@ Usushio では使わない
 			
 			// チューナーをロック
 			try {
-				chinachu.lockTunerSync(tuner);
+				chinachu.lockTunerSync(tuner, true);
 			} catch (e) {
 				util.log('WARNING: チューナー(' + tuner.n + ')のロックに失敗しました');
 				return response.error(500);

--- a/app-operator.js
+++ b/app-operator.js
@@ -242,7 +242,7 @@ function doRecord(program) {
 	
 	// チューナーをロック
 	try {
-		chinachu.lockTunerSync(tuner);
+		chinachu.lockTunerSync(tuner, true);
 	} catch (e) {
 		util.log('WARNING: チューナー(' + tuner.n + ')のロックに失敗しました');
 	}

--- a/chinachu
+++ b/chinachu
@@ -869,7 +869,7 @@ chinachu_unlock () {
     read line
     case $line in
       [yY])
-        rm -vf "${CHINACHU_DIR}"/data/tuner.*.lock && echo "done." && return 0
+        rm -vf "${CHINACHU_DIR}"/data/tuner.*.lock  && rm -vf "${CHINACHU_DIR}"/data/tuner.*.recording && echo "done." && return 0
         ;;
       [nN])
         echo "Abort." && return 0

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -136,12 +136,24 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 			continue;
 		}
 		
+		if (fs.existsSync('./data/tuner.' + j + '.recording') === true && isEpg === true) {
+			continue;
+		}
+		
 		if (fs.existsSync('./data/tuner.' + j + '.lock') === true) {
 			pid = fs.readFileSync('./data/tuner.' + j + '.lock', { encoding: 'utf8' });
 			pid = pid.trim();
 			
 			if (pid === '') {
 				continue;
+			}
+			
+			if (fs.existsSync('./data/tuner.' + j + '.recording') === false && isEpg !== true) {
+				execSync('kill -TERM ' + pid);
+				exports.unlockTunerSync(tuner);
+				fs.writeFile('./data/tuner.' + j + '.recording', "", { flag: 'wx' });
+				freeTuner = tuner;
+				break;
 			}
 			
 			if (execSync('kill -0 ' + pid) !== '') {
@@ -151,6 +163,9 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 			}
 		} else {
 			freeTuner = tuner;
+			if (isEpg !== true) {
+				fs.writeFile('./data/tuner.' + j + '.recording', "", { flag: 'wx' });
+			}
 			break;
 		}
 	}
@@ -184,6 +199,10 @@ exports.unlockTunerSync = function (tuner, safe) {
 				} else {
 					return fs.unlinkSync('./data/tuner.' + tuner.n + '.lock');
 				}
+			}
+		} else {
+			if (fs.existsSync('./data/tuner.' + tuner.n + '.recording')) {
+				fs.unlink('./data/tuner.' + tuner.n + '.recording');
 			}
 		}
 		return fs.unlinkSync('./data/tuner.' + tuner.n + '.lock');

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -120,7 +120,7 @@ exports.existsTunerSync = function (tuners, type) {
 	return isExists;
 };
 
-exports.getFreeTunerSync = function (tuners, type, isEpg) {
+exports.getFreeTunerSync = function (tuners, type, isScheduler) {
 	
 	var j, exists, pid, tuner, freeTuner = null;
 	
@@ -132,11 +132,7 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 			continue;
 		}
 		
-		if (isEpg === true && tuner.noEpg === true) {
-			continue;
-		}
-		
-		if (fs.existsSync('./data/tuner.' + j + '.recording') === true && isEpg === true) {
+		if (isScheduler === true && tuner.noEpg === true) {
 			continue;
 		}
 		
@@ -148,12 +144,28 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 				continue;
 			}
 			
-			if (fs.existsSync('./data/tuner.' + j + '.recording') === false && isEpg !== true) {
-				execSync('kill -TERM ' + pid);
-				exports.unlockTunerSync(tuner);
-				fs.writeFile('./data/tuner.' + j + '.recording', "", { flag: 'wx' });
-				freeTuner = tuner;
-				break;
+			if (fs.existsSync('./data/tuner.' + j + '.recording') === true) {
+				var pid2 = fs.readFileSync('./data/tuner.' + j + '.recording', { encoding: 'utf8' });
+				pid2 = pid2.trim();
+				
+				if (pid2 === '') {
+					continue;
+				}
+				
+				// Scheduler && recording process doesn't exist
+				if (isScheduler === true && execSync('kill -0 ' + pid2) !== '') {
+					exports.unlockTunerSync(tuner);
+					freeTuner = tuner;
+					break;
+				}
+			} else {
+				// If no recording process file exists and not by scheduler process
+				if (isScheduler !== true) {
+					execSync('kill -TERM ' + pid);
+					exports.unlockTunerSync(tuner);
+					freeTuner = tuner;
+					break;
+				}
 			}
 			
 			if (execSync('kill -0 ' + pid) !== '') {
@@ -163,9 +175,6 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 			}
 		} else {
 			freeTuner = tuner;
-			if (isEpg !== true) {
-				fs.writeFile('./data/tuner.' + j + '.recording', "", { flag: 'wx' });
-			}
 			break;
 		}
 	}
@@ -177,8 +186,11 @@ exports.lockTuner = function (tuner, callback) {
 	fs.writeFile('./data/tuner.' + tuner.n + '.lock', process.pid, { flag: 'wx' }, callback);
 };
 
-exports.lockTunerSync = function (tuner) {
+exports.lockTunerSync = function (tuner, isRec) {
 	try {
+		if (isRec === true) {
+			fs.writeFileSync('./data/tuner.' + tuner.n + '.recording', process.pid, { flag: 'wx' });
+		}
 		return fs.writeFileSync('./data/tuner.' + tuner.n + '.lock', process.pid, { flag: 'wx' });
 	} catch (e) {
 		throw e;
@@ -212,11 +224,17 @@ exports.unlockTunerSync = function (tuner, safe) {
 };
 
 exports.writeTunerPid = function (tuner, pid, callback) {
+	if (fs.existsSync('./data/tuner.' + tuner.n + '.recording')) {
+		fs.writeFileSync('./data/tuner.' + tuner.n + '.recording', process.pid, { flag: 'w' });
+	}
 	fs.writeFile('./data/tuner.' + tuner.n + '.lock', pid, { flag: 'w' }, callback);
 };
 
 exports.writeTunerPidSync = function (tuner, pid) {
 	try {
+		if (fs.existsSync('./data/tuner.' + tuner.n + '.recording')) {
+			fs.writeFileSync('./data/tuner.' + tuner.n + '.recording', process.pid, { flag: 'w' });
+		}
 		return fs.writeFileSync('./data/tuner.' + tuner.n + '.lock', pid, { flag: 'w' });
 	} catch (e) {
 		throw e;


### PR DESCRIPTION
    俺:「あっ番組はじまってる　予約してなかった！　録画しよ」（手動予約ぽち）
    Chinachu:「すまんSchedulerが動いてるんだちょっと待ってな？」
    俺:「OK」
    時計: 🕐
    時計: 🕑
    時計: 🕒
    俺:「まだ...？」
    Chinachu:「Scheduler終わったで　今から録画始めるで」
    俺:「最初の5分録画できなかった。。。」


EPG取得のスケジューラーが走ってる時に手動予約をしたりライブ視聴したりすると、
スケジューラーに負けてチューナーロックが待ちキューに入れられてしまうので、優先順位を設けました。
録画の際にdata/tuner.*.recordingを追加で作成し、Schedulerでは作成しないようにし、
もしそのファイルがなければ録画時に、tuner.*.lockを無視して強制的にチューナーを奪い、録画を始めるようにしました。