### PR TITLE
チューナー使用優先度の導入

### DIFF
--- a/api/script-channel-watch.vm.js
+++ b/api/script-channel-watch.vm.js
@@ -111,7 +111,7 @@ Usushio では使わない
 			args.push('-y', '-f', d.f, 'pipe:1');
 
 			// チューナーを選ぶ
-			var tuner = chinachu.getFreeTunerSync(config.tuners, channel.type);
+			var tuner = chinachu.getFreeTunerSync(config.tuners, channel.type, false, 1);
 			
 			// チューナーが見つからない
 			if (tuner === null) {
@@ -127,7 +127,7 @@ Usushio では使わない
 			
 			// チューナーをロック
 			try {
-				chinachu.lockTunerSync(tuner);
+				chinachu.lockTunerSync(tuner, 1);
 			} catch (e) {
 				util.log('WARNING: チューナー(' + tuner.n + ')のロックに失敗しました');
 				return response.error(500);
@@ -141,7 +141,7 @@ Usushio では使わない
 			
 			var recProc = child_process.spawn(recCmd.split(' ')[0], recCmd.replace(/[^ ]+ /, '').split(' '));
 			children.push(recProc.pid);
-			chinachu.writeTunerPid(tuner, recProc.pid);
+			chinachu.writeTunerPidSync(tuner, recProc.pid, 1);
 			util.log('SPAWN: ' + recCmd + ' (pid=' + recProc.pid + ')');
 			
 			recProc.on('exit', function () {

--- a/app-operator.js
+++ b/app-operator.js
@@ -229,7 +229,7 @@ function doRecord(program) {
 	}
 	
 	// チューナーを選ぶ
-	tuner = chinachu.getFreeTunerSync(config.tuners, program.channel.type);
+	tuner = chinachu.getFreeTunerSync(config.tuners, program.channel.type, false, 2);
 	
 	// チューナーが見つからない
 	if (tuner === null) {
@@ -242,7 +242,7 @@ function doRecord(program) {
 	
 	// チューナーをロック
 	try {
-		chinachu.lockTunerSync(tuner);
+		chinachu.lockTunerSync(tuner, 2);
 	} catch (e) {
 		util.log('WARNING: チューナー(' + tuner.n + ')のロックに失敗しました');
 	}
@@ -275,7 +275,7 @@ function doRecord(program) {
 	execRecCmd(function () {
 		// 録画プロセスを生成
 		recProc = child_process.spawn(recCmd.split(' ')[0], recCmd.replace(/[^ ]+ /, '').split(' '));
-		chinachu.writeTunerPid(tuner, recProc.pid);
+		chinachu.writeTunerPidSync(tuner, recProc.pid, 2);
 		util.log('SPAWN: ' + recCmd + ' (pid=' + recProc.pid + ')');
 		program.pid = recProc.pid;
 		

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -901,7 +901,7 @@ function getEpg() {
 			readStream.pipe(writeStream);
 		} else {
 			// チューナーを選ぶ
-			var tuner = chinachu.getFreeTunerSync(config.tuners, channel.type, true);
+			var tuner = chinachu.getFreeTunerSync(config.tuners, channel.type, true, 0);
 			
 			// チューナーが見つからない
 			if (tuner === null) {
@@ -913,7 +913,7 @@ function getEpg() {
 			
 			// チューナーをロック
 			try {
-				chinachu.lockTunerSync(tuner);
+				chinachu.lockTunerSync(tuner, 0);
 			} catch (e) {
 				util.log('[' + i + '] WARNING: チューナー(' + tuner.n + ')のロックに失敗しました');
 				retry();
@@ -941,7 +941,7 @@ function getEpg() {
 			execRecCmd(function () {
 				// 録画プロセスを生成
 				var recProc = child_process.spawn(recCmd.split(' ')[0], recCmd.replace(/[^ ]+ /, '').split(' '));
-				chinachu.writeTunerPidSync(tuner, recProc.pid);
+				chinachu.writeTunerPidSync(tuner, recProc.pid, 0);
 				util.log('[' + i + '] SPAWN: ' + recCmd + ' (pid=' + recProc.pid + ')');
 			
 				// 一時ファイルへの書き込みストリームを作成
@@ -1049,7 +1049,7 @@ function getEpg() {
 		for (i = 0, l = chs.length; i < l; i++) {
 			ch = chs[i];
 			
-			if (!opts.get('ch') && !opts.get('l') && chinachu.getFreeTunerSync(config.tuners, ch.type, true) === null) {
+			if (!opts.get('ch') && !opts.get('l') && chinachu.getFreeTunerSync(config.tuners, ch.type, true, 0) === null) {
 				continue;
 			}
 			

--- a/chinachu
+++ b/chinachu
@@ -869,7 +869,7 @@ chinachu_unlock () {
     read line
     case $line in
       [yY])
-        rm -vf "${CHINACHU_DIR}"/data/tuner.*.lock && echo "done." && return 0
+        rm -vf "${CHINACHU_DIR}"/data/tuner.*.priority && rm -vf "${CHINACHU_DIR}"/data/tuner.*.lock && echo "done." && return 0
         ;;
       [nN])
         echo "Abort." && return 0

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -122,7 +122,7 @@ exports.existsTunerSync = function (tuners, type) {
 
 exports.getFreeTunerSync = function (tuners, type, isEpg, priority) {
 	
-	var j, exists, pid, tuner, freeTuner = null;
+	var j, exists, pid, tuner, freeTuner = null, tunerWillBeUnlocked = null;
 	
 	priority = priority || 0;
 	
@@ -146,29 +146,47 @@ exports.getFreeTunerSync = function (tuners, type, isEpg, priority) {
 				continue;
 			}
 			
-			if (fs.existsSync('./data/tuner.' + j + '.priority') === true) {
-				var tunerPriority = fs.readFileSync('./data/tuner.' + j + '.priority', { encoding: 'utf8' });
-				tunerPriority = tunerPriority.trim();
-				
-				// higher priority than locked tuner
-				if (priority > tunerPriority) {
-					// force terminate the process
-					exports.unlockTunerSync(tuner);
-					execSync('kill -KILL ' + pid);
-					freeTuner = tuner;
-					break;
-				}
-			}
-			
 			if (execSync('kill -0 ' + pid) !== '') {
 				exports.unlockTunerSync(tuner);
 				freeTuner = tuner;
 				break;
 			}
+			
+			if (fs.existsSync('./data/tuner.' + j + '.priority') === true) {
+				var tunerPriority = fs.readFileSync('./data/tuner.' + j + '.priority', { encoding: 'utf8' });
+				tunerPriority = tunerPriority.trim();
+				
+				// Seek the lowest priority
+				if (priority > tunerPriority) {
+					tunerWillBeUnlocked = tuner;
+					if (tunerPriority === 0) {
+						break;
+					}
+					priority = tunerPriority;
+					continue;
+				} else {
+					continue;
+				}
+			}
 		} else {
 			freeTuner = tuner;
 			break;
 		}
+	}
+	
+	if (tunerWillBeUnlocked !== null && freeTuner === null) {
+		tuner = tunerWillBeUnlocked;
+		pid = fs.readFileSync('./data/tuner.' + tuner.n + '.lock', { encoding: 'utf8' });
+		pid = pid.trim();
+			
+		// force terminate the process
+		execSync('kill -KILL ' + pid);
+		try {
+			// If cleanup is not completed
+			exports.unlockTunerSync(tuner);
+		} catch(e) {
+		}
+		freeTuner = tuner;
 	}
 	
 	return freeTuner;

--- a/node_modules/chinachu-common/lib/chinachu-common.js
+++ b/node_modules/chinachu-common/lib/chinachu-common.js
@@ -120,9 +120,11 @@ exports.existsTunerSync = function (tuners, type) {
 	return isExists;
 };
 
-exports.getFreeTunerSync = function (tuners, type, isEpg) {
+exports.getFreeTunerSync = function (tuners, type, isEpg, priority) {
 	
 	var j, exists, pid, tuner, freeTuner = null;
+	
+	priority = priority || 0;
 	
 	for (j = 0; tuners.length > j; j++) {
 		tuner = tuners[j];
@@ -144,6 +146,20 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 				continue;
 			}
 			
+			if (fs.existsSync('./data/tuner.' + j + '.priority') === true) {
+				var tunerPriority = fs.readFileSync('./data/tuner.' + j + '.priority', { encoding: 'utf8' });
+				tunerPriority = tunerPriority.trim();
+				
+				// higher priority than locked tuner
+				if (priority > tunerPriority) {
+					// force terminate the process
+					exports.unlockTunerSync(tuner);
+					execSync('kill -KILL ' + pid);
+					freeTuner = tuner;
+					break;
+				}
+			}
+			
 			if (execSync('kill -0 ' + pid) !== '') {
 				exports.unlockTunerSync(tuner);
 				freeTuner = tuner;
@@ -158,12 +174,10 @@ exports.getFreeTunerSync = function (tuners, type, isEpg) {
 	return freeTuner;
 };
 
-exports.lockTuner = function (tuner, callback) {
-	fs.writeFile('./data/tuner.' + tuner.n + '.lock', process.pid, { flag: 'wx' }, callback);
-};
-
-exports.lockTunerSync = function (tuner) {
+exports.lockTunerSync = function (tuner, priority) {
 	try {
+		priority = priority || 0;
+		fs.writeFileSync('./data/tuner.' + tuner.n + '.priority', priority, { flag: 'wx' });
 		return fs.writeFileSync('./data/tuner.' + tuner.n + '.lock', process.pid, { flag: 'wx' });
 	} catch (e) {
 		throw e;
@@ -171,6 +185,9 @@ exports.lockTunerSync = function (tuner) {
 };
 
 exports.unlockTuner = function (tuner, callback) {
+	if (fs.existsSync('./data/tuner.' + tuner.n + '.priority')) {
+		fs.unlinkSync('./data/tuner.' + tuner.n + '.priority');
+	}
 	fs.unlink('./data/tuner.' + tuner.n + '.lock', callback);
 };
 
@@ -182,9 +199,15 @@ exports.unlockTunerSync = function (tuner, safe) {
 				if (execSync('kill -0 ' + pid) === '') {
 					return null;
 				} else {
+					if (fs.existsSync('./data/tuner.' + tuner.n + '.priority')) {
+						fs.unlinkSync('./data/tuner.' + tuner.n + '.priority');
+					}
 					return fs.unlinkSync('./data/tuner.' + tuner.n + '.lock');
 				}
 			}
+		}
+		if (fs.existsSync('./data/tuner.' + tuner.n + '.priority')) {
+			fs.unlinkSync('./data/tuner.' + tuner.n + '.priority');
 		}
 		return fs.unlinkSync('./data/tuner.' + tuner.n + '.lock');
 	} catch (e) {
@@ -192,12 +215,10 @@ exports.unlockTunerSync = function (tuner, safe) {
 	}
 };
 
-exports.writeTunerPid = function (tuner, pid, callback) {
-	fs.writeFile('./data/tuner.' + tuner.n + '.lock', pid, { flag: 'w' }, callback);
-};
-
-exports.writeTunerPidSync = function (tuner, pid) {
+exports.writeTunerPidSync = function (tuner, pid, priority) {
 	try {
+		priority = priority || 0;
+		fs.writeFileSync('./data/tuner.' + tuner.n + '.priority', priority, { flag: 'w' });
 		return fs.writeFileSync('./data/tuner.' + tuner.n + '.lock', pid, { flag: 'w' });
 	} catch (e) {
 		throw e;


### PR DESCRIPTION
クライアントでライブ視聴をよくするので、ライブ視聴に関するチューナー優先度を導入しました。
ライブ視聴時に録画が始まった際にチューナーが足りずに録画できない問題を解消すべく、

| チューナー使用タイプ | 優先度 |
|:-------------------------------|:--------:|
|スケジューラー             |  低(0)  |
|ライブ視聴                    |  中(1)  |
|録画                               |  高(2)  |

として優先度順にチューナーを奪取できるようにしました。

ついでに使われていない処理を掃除しました。