### PR TITLE
package.jsonのenginesの項を4.0.0に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "test": "mocha -R spec"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4.0.0"
   }
 }


### PR DESCRIPTION
アップデートで使用している人がv0.12.x特有の問題を踏んだときに面倒なことが起こらないかなーという心配で、念のためにpackage.jsonにもv4.0.0にしたことを記載しました。