### PR TITLE
ストリーミング再生画面にダウンロードボタンを追加

### DIFF
--- a/api/script-recorded-program-watch.vm.js
+++ b/api/script-recorded-program-watch.vm.js
@@ -125,6 +125,11 @@ function main(avinfo) {
 			}
 			tsize = Math.floor(tsize);
 			
+			if (request.query.mode == 'download') {
+				var pi = path.parse(program.recorded);
+				response.setHeader('Content-disposition', 'attachment; filename*=UTF-8\'\'' + encodeURIComponent(pi.name + '.' + request.query.ext));
+			}
+
 			// Ranges Support
 			var range = {};
 			if (request.type === 'mp4') {

--- a/web/page/program/watch.js
+++ b/web/page/program/watch.js
@@ -108,55 +108,73 @@ P = Class.create(P, {
 			set['b:a'] = '96k';
 		}
 
+		var buttons = [
+			{
+				label  : '再生',
+				color  : '@pink',
+				onSelect: function(e, modal) {
+					if (this.form.validate() === false) { return; }
+
+					var d = this.d = this.form.result();
+
+					saveSettings(d);
+
+					if ((d.ext === 'm2ts') && (!window.navigator.plugins['VLC Web Plugin'])) {
+						new flagrate.Modal({
+							title: 'エラー',
+							text : 'MPEG-2 TSコンテナの再生にはVLC Web Pluginが必要です。'
+						}).show();
+						return;
+					}
+
+					modal.close();
+
+					this.play();
+				}.bind(this)
+			},
+			{
+				label  : 'XSPF',
+				color  : '@orange',
+				onSelect: function(e, modal) {
+					if (this.form.validate() === false) { return; }
+
+					var d = this.form.result();
+
+					saveSettings(d);
+
+					if (program._isRecording) {
+						d.prefix = window.location.protocol + '//' + window.location.host + '/api/recording/' + program.id + '/';
+						window.open('./api/recording/' + program.id + '/watch.xspf?' + Object.toQueryString(d));
+					} else {
+						d.prefix = window.location.protocol + '//' + window.location.host + '/api/recorded/' + program.id + '/';
+						window.open('./api/recorded/' + program.id + '/watch.xspf?' + Object.toQueryString(d));
+					}
+				}.bind(this)
+			}
+		];
+		if (! program._isRecording) {
+			buttons.push({
+				label: 'ダウンロード',
+				color: '@blue',
+				onSelect: function(e, model) {
+					if (this.form.validate() === false) { return; }
+
+					var d = this.form.result();
+
+					saveSettings(d);
+
+					d.prefix = window.location.protocol + '//' + window.location.host + '/api/recording/' + program.id + '/';
+					d.mode = 'download';
+					location.href = './api/recorded/' + program.id + '/watch.' + d.ext + '?' + Object.toQueryString(d);
+				}.bind(this)
+			});
+		}
 		var modal = this.modal = new flagrate.Modal({
 			disableCloseByMask: true,
 			disableCloseButton: true,
 			target: this.view.content,
 			title : 'ストリーミング再生',
-			buttons: [
-				{
-					label  : '再生',
-					color  : '@pink',
-					onSelect: function(e, modal) {
-						if (this.form.validate() === false) { return; }
-
-						var d = this.d = this.form.result();
-
-						saveSettings(d);
-
-						if ((d.ext === 'm2ts') && (!window.navigator.plugins['VLC Web Plugin'])) {
-							new flagrate.Modal({
-								title: 'エラー',
-								text : 'MPEG-2 TSコンテナの再生にはVLC Web Pluginが必要です。'
-							}).show();
-							return;
-						}
-
-						modal.close();
-
-						this.play();
-					}.bind(this)
-				},
-				{
-					label  : 'XSPF',
-					color  : '@orange',
-					onSelect: function(e, modal) {
-						if (this.form.validate() === false) { return; }
-
-						var d = this.form.result();
-
-						saveSettings(d);
-
-						if (program._isRecording) {
-							d.prefix = window.location.protocol + '//' + window.location.host + '/api/recording/' + program.id + '/';
-							window.open('./api/recording/' + program.id + '/watch.xspf?' + Object.toQueryString(d));
-						} else {
-							d.prefix = window.location.protocol + '//' + window.location.host + '/api/recorded/' + program.id + '/';
-							window.open('./api/recorded/' + program.id + '/watch.xspf?' + Object.toQueryString(d));
-						}
-					}.bind(this)
-				}
-			]
+			buttons: buttons
 		}).show();
 
 		if (Prototype.Browser.MobileSafari) {


### PR DESCRIPTION
ストリーミング再生を開始する画面に、設定したエンコード設定でmp4ファイルやwebmファイルをダウンロードするボタンを追加しました。

追加内容は、画面へのボタン追加と、
api/script-recorded-program-watch.vm.js
がContent-Dispositionヘッダを出力できるようにする部分です。

ご確認、よろしくお願いいたします。

インデントを１段変えている部分がありますので、[空白無視モード](https://github.com/kanreisa/Chinachu/pull/230/files?w=)でdiffをご覧になられるのが良いかと思います。