### PR TITLE
Fix recorded programs streaming range

### DIFF
--- a/api/script-recorded-program-watch.vm.js
+++ b/api/script-recorded-program-watch.vm.js
@@ -133,7 +133,7 @@ function main(avinfo) {
 				response.setHeader('Content-Length', tsize);
 				
 				response.head(200);
-			} else if (d.ss !== '0') {
+			} else if (d.ss !== '2') {
 				range.start = parseInt(ibitrate / 8 * (parseInt(d.ss, 10) - 2), 10);
 				
 				response.setHeader('Content-Length', tsize);


### PR DESCRIPTION
9cf3545aeebd4c53855056e7805390ed6e5eedde にて、d.ssの最小値が'2'に変更されているのにもかかわらず、Range付きリクエストの判定で'0'と比較していたのでその部分を修正。