### PR TITLE
EPG取得中などでスケジューラの実行に失敗したときにWUIで失敗が分かるようにする

### DIFF
--- a/chinachu
+++ b/chinachu
@@ -739,7 +739,8 @@ EOF
 }
 
 chinachu_update () {
-  node app-scheduler.js "$@" > /dev/stdout 2>&1 | tee -a ./log/scheduler && return 0
+  node app-scheduler.js "$@" > /dev/stdout 2>&1 | tee -a ./log/scheduler
+  return ${PIPESTATUS[0]}
 }
 
 chinachu_search () {

--- a/chinachu
+++ b/chinachu
@@ -706,7 +706,8 @@ chinachu_service_execute () {
   ensure_dir log
   ensure_dir data
   
-  node app-${name}.js > /dev/stdout 2>&1 | tee -a ./log/${name} && return 0
+  node app-${name}.js > /dev/stdout 2>&1 | tee -a ./log/${name}
+  return ${PIPESTATUS[0]}
 }
 
 chinachu_service_help () {
@@ -759,7 +760,8 @@ chinachu_reserve () {
     read line
     case ${line:-y} in
       [yY])
-        node app-scheduler.js > /dev/stdout 2>&1 | tee -a ./log/scheduler && return 0
+        node app-scheduler.js > /dev/stdout 2>&1 | tee -a ./log/scheduler
+        return ${PIPESTATUS[0]}
         ;;
       [nN])
         echo "Ok." && return 0


### PR DESCRIPTION
WUIでスケジューラを実行したときに、裏でEPG取得が走っているとき、`chinachu update`では
ERROR: Scheduler is already running.
と出力するにも関わらず、リターンコード0で終了していました。

そのため、/api/scheduler.jsonにputしても200が返り、WUIに「スケジュール実行成功」と表示されていました。

このパッチで、失敗がリターンコードで返るようになるため、WUIに「失敗」と表示されるようになります。
本当は「Scheduler is already running.」を画面に表示したかったのですが、apiに手を入れるのにためらわれたため、ここまででPRとします。

同じ構文があと2箇所ありますが、どうしましょうかね？