### PR TITLE
手動予約した番組が競合していると、手動予約した情報が消えてしまう問題に対応

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -8,6 +8,7 @@
 var CONFIG_FILE         = __dirname + '/config.json';
 var RULES_FILE          = __dirname + '/rules.json';
 var RESERVES_DATA_FILE  = __dirname + '/data/reserves.json';
+var MANUAL_RESERVES_DATA_FILE = __dirname + '/data/manual_reserves.json';
 var SCHEDULE_DATA_FILE  = __dirname + '/data/schedule.json';
 var RECORDING_DATA_FILE = __dirname + '/data/recording.json';
 var RECORDED_DATA_FILE  = __dirname + '/data/recorded.json';
@@ -255,6 +256,7 @@ var config    = require(CONFIG_FILE);
 var rules     = JSON.parse( fs.readFileSync(RULES_FILE,          { encoding: 'utf8' }) || '[]' );
 var schedule  = JSON.parse( fs.readFileSync(SCHEDULE_DATA_FILE,  { encoding: 'utf8' }) || '[]' );
 var reserves  = JSON.parse( fs.readFileSync(RESERVES_DATA_FILE,  { encoding: 'utf8' }) || '[]' );
+var manual_reserves = JSON.parse( fs.readFileSync(MANUAL_RESERVES_DATA_FILE, { encoding: 'utf8'}) || '[]' );
 var recording = JSON.parse( fs.readFileSync(RECORDING_DATA_FILE, { encoding: 'utf8' }) || '[]' );
 var recorded  = JSON.parse( fs.readFileSync(RECORDED_DATA_FILE,  { encoding: 'utf8' }) || '[]' );
 var channels  = JSON.parse( JSON.stringify(config.channels) );
@@ -427,6 +429,11 @@ function chinachuReserve() {
 		return a.start - b.start;
 	});
 	
+	manual_reserves.push(target);
+	manual_reserves.sort(function(a, b) {
+		return a.start - b.start;
+	});
+	
 	if (opts.get('simulation')) {
 		console.log('[simulation] reserve:');
 		console.log(JSON.stringify(target, null, '  '));
@@ -435,6 +442,7 @@ function chinachuReserve() {
 		console.log(JSON.stringify(target, null, '  '));
 		
 		fs.writeFileSync(RESERVES_DATA_FILE, JSON.stringify(reserves));
+		fs.writeFileSync(MANUAL_RESERVES_DATA_FILE, JSON.stringify(manual_reserves));
 		
 		console.log('予約しました。 スケジューラーを実行して競合を確認することをお勧めします');
 	}
@@ -463,6 +471,13 @@ function chinachuUnreserve() {
 		}
 	}
 	
+	for (var i = 0; manual_reserves.length > i; i++) {
+		if (target.id === manual_reserves[i].id) {
+			manual_reserves.splice(i, 1);
+			break;
+		}
+	}
+	
 	if (opts.get('simulation')) {
 		console.log('[simulation] unreserve:');
 		console.log(JSON.stringify(target, null, '  '));
@@ -471,6 +486,7 @@ function chinachuUnreserve() {
 		console.log(JSON.stringify(target, null, '  '));
 		
 		fs.writeFileSync(RESERVES_DATA_FILE, JSON.stringify(reserves));
+		fs.writeFileSync(MANUAL_RESERVES_DATA_FILE, JSON.stringify(manual_reserves));
 		
 		console.log('予約を解除しました。 ');
 	}

--- a/app-cli.js
+++ b/app-cli.js
@@ -413,7 +413,7 @@ function chinachuReserve() {
 		process.exit(1);
 	}
 	
-	if (chinachu.getProgramById(opts.get('id'), reserves) !== null) {
+	if (chinachu.getProgramById(opts.get('id'), reserves) !== null || chinachu.getProgramById(opt.get('id'), manual_reserves) !== null) {
 		util.error('既に予約されています');
 		process.exit(1);
 	}

--- a/app-cli.js
+++ b/app-cli.js
@@ -413,7 +413,7 @@ function chinachuReserve() {
 		process.exit(1);
 	}
 	
-	if (chinachu.getProgramById(opts.get('id'), reserves) !== null || chinachu.getProgramById(opt.get('id'), manual_reserves) !== null) {
+	if (chinachu.getProgramById(opts.get('id'), reserves) !== null || chinachu.getProgramById(opts.get('id'), manual_reserves) !== null) {
 		util.error('既に予約されています');
 		process.exit(1);
 	}

--- a/app-operator.js
+++ b/app-operator.js
@@ -9,6 +9,7 @@
 
 var CONFIG_FILE         = __dirname + '/config.json';
 var RESERVES_DATA_FILE  = __dirname + '/data/reserves.json';
+var MANUAL_RESERVES_DATA_FILE = __dirname + '/data/manual_reserves.json';
 var RECORDING_DATA_FILE = __dirname + '/data/recording.json';
 var RECORDED_DATA_FILE  = __dirname + '/data/recorded.json';
 
@@ -44,6 +45,7 @@ var chinachu   = require('chinachu-common');
 
 //
 var reserves  = [];
+var manual_reserves = [];
 var recorded  = [];
 var recording = [];
 
@@ -347,6 +349,14 @@ function doRecord(program) {
 						break;
 					}
 				}
+				for (i = 0, l = manual_reserves.length; i < l; i++) {
+					if (manual_reserves[i].id === program.id) {
+						manual_reserves.splice(i, 1);
+						fs.writeFileSync(MANUAL_RESERVES_DATA_FILE, JSON.stringify(manual_reserves));
+						util.log('WRITE: ' + MANUAL_RESERVES_DATA_FILE);
+						break;
+					}
+				}
 			}
 			
 			// ポストプロセス
@@ -480,6 +490,21 @@ chinachu.jsonWatcher(
 			fs.writeFileSync(RECORDING_DATA_FILE, JSON.stringify(recording));
 			util.log('WRITE: ' + RECORDING_DATA_FILE);
 		}
+	},
+	{ create: [], now: true }
+);
+ 
+// ファイル更新監視: ./data/manual_reserves.json
+chinachu.jsonWatcher(
+	MANUAL_RESERVES_DATA_FILE,
+	function _onUpdated(err, data, mes) {
+		if (err) {
+			console.error(err);
+			return;
+		}
+		
+		manual_reserves = data;
+		util.log(mes);
 	},
 	{ create: [], now: true }
 );

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -12,6 +12,7 @@ var PID_FILE = __dirname + '/data/scheduler.pid';
 var CONFIG_FILE         = __dirname + '/config.json';
 var RULES_FILE          = __dirname + '/rules.json';
 var RESERVES_DATA_FILE  = __dirname + '/data/reserves.json';
+var MANUAL_RESERVES_DATA_FILE = __dirname + '/data/manual_reserves.json';
 var SCHEDULE_DATA_FILE  = __dirname + '/data/schedule.json';
 
 // 標準モジュールのロード
@@ -69,6 +70,7 @@ opts.parse([
 var config   = require(CONFIG_FILE);
 var rules    = JSON.parse(fs.readFileSync(RULES_FILE, { encoding: 'utf8' }) || '[]');
 var reserves = null;//まだ読み込まない
+var manual_reserves = null;//まだ読み込まない
 
 // チャンネルリスト
 var channels = JSON.parse(JSON.stringify(config.channels));
@@ -187,6 +189,7 @@ function scheduler() {
 	});
 	
 	reserves = JSON.parse(fs.readFileSync(RESERVES_DATA_FILE, { encoding: 'utf8' }) || '[]');//読み込む
+	manual_reserves = JSON.parse(fs.readFileSync(MANUAL_RESERVES_DATA_FILE, { encoding: 'utf8' }) || '[]');
 	
 	var typeNum = {};
 	
@@ -235,6 +238,20 @@ function scheduler() {
 				}
 			}
 			return;
+		}
+	});
+	
+	manual_reserves.forEach(function (reserve) {
+		var found = false;
+		var i, l;
+		for (i = 0, l = matches.length; i < l; i++) {
+			if (matches[i].id === reserve.id) {
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			matches.push(reserve);
 		}
 	});
 	

--- a/web/class.js
+++ b/web/class.js
@@ -639,7 +639,7 @@
 							onSuccess: function () {
 								new flagrate.Modal({
 									title: '成功',
-									text : '予約しました'
+									text : '予約しました。競合を確認するためスケジューラを実行することをお勧めします'
 								}).show();
 							},
 							onFailure: function (t) {
@@ -670,7 +670,7 @@
 								onSuccess: function () {
 									new flagrate.Modal({
 										title: '成功',
-										text : '予約しました'
+										text : '予約しました。競合を確認するためスケジューラを実行することをお勧めします'
 									}).show();
 								},
 								onFailure: function (t) {
@@ -739,7 +739,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : '予約を取り消しました'
+											text : '予約を取り消しました。競合を解決するにはスケジューラを実行する必要があります'
 										}).show();
 									},
 									onFailure: function (t) {
@@ -801,7 +801,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : 'スキップを有効にしました'
+											text : 'スキップを有効にしました。競合を解決するにはスケジューラを実行する必要があります'
 										}).show();
 									},
 									onFailure: function (t) {
@@ -863,7 +863,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : 'スキップを取り消しました'
+											text : 'スキップを取り消しました。競合を確認するため、スケジューラの実行をお勧めします'
 										}).show();
 									},
 									onFailure: function (t) {


### PR DESCRIPTION
例えば、18:00～19:00の番組Aを手動またはルールで予約している状態で、18:30～19:00の番組Bを手動予約するとします。（チューナは1つとします）
その後、スケジューラを実行すると、番組Bがチューナ不足により、競合状態になるため、reserves.jsonから消えます。
このとき、番組Bの情報はreserves.jsonを含めどのファイルにも残っていないため、番組Aの予約取り消し（ルールの場合はルール削除 or スキップ）をして再度スケジューラを実行しても番組Bが予約されません。

そこで、data/manual_reserve.jsonに手動予約の情報を保存しておくことで、再度スケジューラを実行すれば番組Bが予約できるようにしました。

できればWUIから競合状態が分かるようにしたいところですが、とりあえず手動予約を保存しておくだけのところでPRとします。