### PR TITLE
手動予約した番組が競合していると、手動予約した情報が消えてしまう問題に対応＠reserves.jsonだけでやる版

### DIFF
--- a/app-cli.js
+++ b/app-cli.js
@@ -771,6 +771,7 @@ function chinachuProgramList(target) {
 		if (opts.get('simple')) {
 			t.cell('Datetime', dateFormat(new Date(a.start), 'dd HH:MM'));
 		} else {
+			// TODO: isConflict を見る
 			t.cell('By', a.isManualReserved ? 'user' : 'rule');
 			t.cell('Datetime', dateFormat(new Date(a.start), 'yy/mm/dd HH:MM'));
 		}

--- a/app-operator.js
+++ b/app-operator.js
@@ -413,8 +413,8 @@ function prepRecord(program) {
 
 // 予約時間チェック
 function reservesChecker(program, i) {
-	// スキップ
-	if (program.isSkip) { return undefined; }
+	// スキップ または 競合
+	if (program.isSkip || program.isConflict) { return undefined; }
 	
 	// 予約時間超過
 	if (clock > program.end) {

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -325,15 +325,17 @@ function scheduler() {
 	for (i = 0; i < matches.length; i++) {
 		a = matches[i];
 		
-		if (!a.isConflict && !a.isDuplicate) {
+		if (!a.isDuplicate) {
 			reserves.push(a);
 			
 			if (a.isSkip) {
 				util.log('!!!SKIP: ' + a.id + ' ' + dateFormat(new Date(a.start), 'isoDateTime') + ' [' + a.channel.name + '] ' + a.title);
 				++skipCount;
-			} else {
+			} else if (!a.isConflict) {
 				util.log('RESERVE: ' + a.id + ' ' + dateFormat(new Date(a.start), 'isoDateTime') + ' [' + a.channel.name + '] ' + a.title);
 				++reservedCount;
+			} else {
+				// 競合したときのログは既に出力済み
 			}
 		}
 	}

--- a/web/chinachu.css
+++ b/web/chinachu.css
@@ -1053,6 +1053,9 @@ div.dashboard-timelist[rel="3"]:last-child {
 		div.dashboard-timelist > div.main > a.skip {
 			opacity: 0.4; }
 		
+		div.dashboard-timelist > div.main > a.conflict {
+			opacity: 0.4; ;}
+		
 		div.dashboard-timelist > div.main > a:hover {
 			z-index        : 2;
 			background     : rgba(0,0,0,0.25);
@@ -1193,6 +1196,9 @@ div.timetable > div.board {
 		background  : white !important; }
 	
 	div.timetable > div.board > div.rect.skip {
+		background  : gray !important; }
+	
+	div.timetable > div.board > div.rect.conflict {
 		background  : gray !important; }
 	
 	div.timetable > div.board > div.rect.muted {
@@ -1490,6 +1496,9 @@ td > div > span.flag {
 	color       : #fff;
 	font-size   : 11px;
 	background  : #999; }
+
+td > div > span.flag.conflict {
+	background: #f00; }
 
 td > div > span.flag.manual {
 	background  : #000; }

--- a/web/class.js
+++ b/web/class.js
@@ -639,7 +639,7 @@
 							onSuccess: function () {
 								new flagrate.Modal({
 									title: '成功',
-									text : '予約しました'
+									text : '予約しました。競合を確認するためスケジューラを実行することをお勧めします'
 								}).show();
 							},
 							onFailure: function (t) {
@@ -670,7 +670,7 @@
 								onSuccess: function () {
 									new flagrate.Modal({
 										title: '成功',
-										text : '予約しました'
+										text : '予約しました。競合を確認するためスケジューラを実行することをお勧めします'
 									}).show();
 								},
 								onFailure: function (t) {
@@ -739,7 +739,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : '予約を取り消しました'
+											text : '予約を取り消しました。競合を解決するにはスケジューラを実行する必要があります'
 										}).show();
 									},
 									onFailure: function (t) {
@@ -801,7 +801,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : 'スキップを有効にしました'
+											text : 'スキップを有効にしました。競合を解決するにはスケジューラを実行する必要があります'
 										}).show();
 									},
 									onFailure: function (t) {
@@ -863,7 +863,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : 'スキップを取り消しました'
+											text : 'スキップを取り消しました。競合を確認するため、スケジューラの実行をお勧めします'
 										}).show();
 									},
 									onFailure: function (t) {

--- a/web/class.js
+++ b/web/class.js
@@ -670,7 +670,7 @@
 								onSuccess: function () {
 									new flagrate.Modal({
 										title: '成功',
-										text : '予約しました。競合を確認するためスケジューラを実行することをお勧めします'
+										text : '予約しました。スケジューラーを実行して競合を確認することをお勧めします'
 									}).show();
 								},
 								onFailure: function (t) {
@@ -863,7 +863,7 @@
 									onSuccess: function () {
 										new flagrate.Modal({
 											title: '成功',
-											text : 'スキップを取り消しました。競合を確認するため、スケジューラの実行をお勧めします'
+											text : 'スキップを取り消しました。スケジューラーを実行して競合を確認することをお勧めします'
 										}).show();
 									},
 									onFailure: function (t) {

--- a/web/page/dashboard/top.js
+++ b/web/page/dashboard/top.js
@@ -208,6 +208,9 @@
 								}
 							});
 						} else if (program._data._isReserves) {
+							if (program.isConflict) {
+								program._it.entity.addClassName('conflict');
+							}
 							if (program.isManualReserved) {
 								contextMenuItems.unshift({
 									label   : '予約取消...',

--- a/web/page/program/view.js
+++ b/web/page/program/view.js
@@ -229,6 +229,13 @@ P = Class.create(P, {
 					body        : 'この番組は自動録画予約されましたがスキップするように設定されています',
 					disableClose: true
 				}).render(this.view.content);
+			} else if (program.isConflict) {
+				new sakura.ui.Alert({
+					title       : '競合',
+					type        : 'red',
+					body        : 'この番組は録画予約されていますが、競合のため録画されません',
+					disableClose: true
+				}).render(this.view.content);
 			} else {
 				new sakura.ui.Alert({
 					title       : '予約済',

--- a/web/page/reserves/list.js
+++ b/web/page/reserves/list.js
@@ -271,6 +271,10 @@ P = Class.create(P, {
 					});
 				}
 			}
+			if (program.isConflict) {
+				titleHtml = '<span class="flag conflict">競合</span>' + titleHtml;
+				row.className += ' disabled';
+			}
 			
 			row.cell.title = {
 				sortAlt    : program.title,

--- a/web/page/schedule/table.js
+++ b/web/page/schedule/table.js
@@ -426,6 +426,9 @@
 				if (program.isSkip) {
 					piece[program.id].isSkip = true;
 				}
+				if (program.isConflict) {
+					piece[program.id].isConflict = true;
+				}
 			});
 			
 			global.chinachu.recording.forEach(function (program) {
@@ -978,6 +981,9 @@
 											var dummy = new chinachu.ui.Skip(a.program.id);
 										}
 									});
+								}
+								if (a.isConflict) {
+									a._rect.addClassName('conflict');
 								}
 							} else {
 								contextMenuItems.unshift({


### PR DESCRIPTION
#237 の別アプローチです。
data以下のファイルを増やさないように、reserves.jsonの中に競合している番組も残すように変更しました。

思っていたよりも変更点が少なかったのでこちらの方が良いかもしれません。（WUIへの変更は多くなっていますが）

CSSの変更はおおむねスキップしている番組に準ずる見た目にしていますが、クラスを分けてあるので、適宜修正お願いします。

後、迷っているところとして、./chinachu reserves したときの出力でどう見せようかというところ。
・・・スキップしていても表示しないし、このままでも良いですかね？