### PR TITLE
手動予約した番組にマッチするルールを作成すると起こる問題に対応

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -217,17 +217,14 @@ function scheduler() {
 		var i, l;
 		if (reserve.isManualReserved) {
 			if (reserve.start + 86400000 > Date.now()) {
-				var isOneseg = reserve['1seg'] === true;
 				for (i = 0, l = matches.length; i < l; i++) {
 					if (matches[i].id === reserve.id) {
-						// ルールと重複していた場合、プロパティをセットしてreturn
-						matches[i].isManualReserved = true;
-						if (isOneseg === true) {
-							matches[i]['1seg'] = true;
-						}
+						// ルールと重複していた場合、ルール予約が手動予約に優先するよう、matchesにpushせずreturnする
+						util.log('OVERRIDEBYRULE: ' + reserve.id + ' ' + dateFormat(new Date(reserve.start), 'isoDateTime') + ' [' + reserve.channel.name + '] ' + reserve.title);
 						return;
 					}
 				}
+				var isOneseg = reserve['1seg'] === true;
 				reserve = chinachu.getProgramById(reserve.id, schedule) || reserve;
 				reserve.isManualReserved = true;
 				if (isOneseg === true) {

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -214,9 +214,20 @@ function scheduler() {
 	});
 	
 	reserves.forEach(function (reserve) {
+		var i, l;
 		if (reserve.isManualReserved) {
 			if (reserve.start + 86400000 > Date.now()) {
 				var isOneseg = reserve['1seg'] === true;
+				for (i = 0, l = matches.length; i < l; i++) {
+					if (matches[i].id === reserve.id) {
+						// ルールと重複していた場合、プロパティをセットしてreturn
+						matches[i].isManualReserved = true;
+						if (isOneseg === true) {
+							matches[i]['1seg'] = true;
+						}
+						return;
+					}
+				}
 				reserve = chinachu.getProgramById(reserve.id, schedule) || reserve;
 				reserve.isManualReserved = true;
 				if (isOneseg === true) {
@@ -226,7 +237,6 @@ function scheduler() {
 			}
 			return;
 		}
-		var i, l;
 		if (reserve.isSkip) {
 			for (i = 0, l = matches.length; i < l; i++) {
 				if (matches[i].id === reserve.id) {


### PR DESCRIPTION
手動予約した番組にマッチするルールを作成し、スケジューラを実行すると同じ番組が重複して予約に追加されていました。その結果、

* 同一時間の他の予約が競合でキャンセルされる（手動の場合は予約情報が消える）
* タイミングによってはその番組の予約情報が全部消えていて、録画が実行されない
* （未確認）同一ファイル名で録画しようとするので何か問題が起こりそう

といった問題が起こっていました。

スケジューラで手動予約の情報をコピーするときに、ルールによって予約されているかをチェックしていなかったことが原因なので、チェックロジックを追加しました。

ワンセグフラグは残していますが、スキップフラグについては無視しました。手動予約が入っていればスキップフラグを立てることができないはずなので。