### PR TITLE
Improve regular expressions for titles and episode numbers

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -385,7 +385,7 @@ function convertPrograms(p, ch) {
 		title = title
 			.replace(/【.{1,2}】/g, '')
 			.replace(/\[.\]/g, '')
-			.replace(/[「|（|#|＃|♯|第]+[0-9０-９零一壱二弐三参四五伍六七八九十拾]+[話|回|」|）]*/g, '');
+			.replace(/[「（#＃♯第]+[0-9０-９零一壱二弐三参四五伍六七八九十拾]+[話回」）]*/g, '');
 		
 		if (c.category[1]._ === 'anime') {
 			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1');
@@ -415,7 +415,7 @@ function convertPrograms(p, ch) {
 		}
 		
 		var episodeNumber = null;
-		var episodeNumberMatch = (c.title[0]._ + ' ' + desc).match(/[「|（|#|＃|♯|第]+([0-9０-９零一壱二弐三参四五伍六七八九十拾]+)[話|回|」|）]*|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
+		var episodeNumberMatch = (c.title[0]._ + ' ' + desc).match(/[「（#＃♯第]+[0-9０-９零一壱二弐三参四五伍六七八九十拾]+[話回」）]*|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
 		if (episodeNumberMatch !== null) {
 			var episodeNumberString = episodeNumberMatch[0];
 

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -415,12 +415,12 @@ function convertPrograms(p, ch) {
 		}
 		
 		var episodeNumber = null;
-		var episodeNumberMatch = (c.title[0]._ + ' ' + desc).match(/(#|＃|♯)[0-9０１２３４５６７８９]+|第([0-9]+|[０１２３４５６７８９零一二三四五六七八九十]+)(話|回)|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
+		var episodeNumberMatch = (c.title[0]._ + ' ' + desc).match(/[「|（|#|＃|♯|第]+([0-9０-９零一壱二弐三参四五伍六七八九十拾]+)[話|回|」|）]*|Episode ?[IⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪⅫVX]+/);
 		if (episodeNumberMatch !== null) {
 			var episodeNumberString = episodeNumberMatch[0];
 
 			episodeNumberString = episodeNumberString
-				.replace(/#|＃|♯|第|話|回/g, '')
+				.replace(/「|（|#|＃|♯|第|話|回|」|）/g, '')
 				.replace(/０|零/g, '0')
 				.replace(/４|Ⅳ|IV|ＩＶ/g, '4')
 				.replace(/８|Ⅷ|VIII|ＶＩＩＩ/g, '8')

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -385,8 +385,7 @@ function convertPrograms(p, ch) {
 		title = title
 			.replace(/【.{1,2}】/g, '')
 			.replace(/\[.\]/g, '')
-			.replace(/(#|＃|♯)[0-9０１２３４５６７８９]+/g, '')
-			.replace(/第([0-9]+|[０１２３４５６７８９零一壱二弐三参四五伍六七八九十拾]+)(話|回)/g, '');
+			.replace(/[「|（|#|＃|♯|第]+[0-9０-９零一壱二弐三参四五伍六七八九十拾]+[話|回|」|）]*/g, '');
 		
 		if (c.category[1]._ === 'anime') {
 			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1');


### PR DESCRIPTION
#192 と #204 とほぼ同じ（若干異なる）ことを比較的シンプルに，かつ汎用的に実現するパッチです。これまで上手く処理できなかった以下の様なタイトルと話数の処理を改善します。

* 【字】ワンピース（第４５２話）
* 連続テレビ小説　あさが来た（１８）「新選組参上！」【解】【字】【デ】
* 韓国ドラマ・トライアングル「３話」【日本語字幕】