### PR TITLE
WUI/Client: リバースプロキシ使用時に再生できない問題を修正

### DIFF
--- a/web/page/channel/watch.js
+++ b/web/page/channel/watch.js
@@ -102,7 +102,8 @@ P = Class.create(P, {
 
 						var d = this.form.result();
 
-						d.prefix = window.location.protocol + '//' + window.location.host + '/api/channel/' + this.channelId + '/';
+						d.prefix = window.location.protocol + '//' + window.location.host;
+						d.prefix += window.location.pathname.replace(/\/[^\/]*$/, '') + '/api/channel/' + this.channelId + '/';
 						window.open('./api/channel/' + this.channelId + '/watch.xspf?' + Object.toQueryString(d));
 					}.bind(this)
 				}
@@ -432,7 +433,7 @@ P = Class.create(P, {
 
 		var getRequestURI = function() {
 
-			var r = window.location.protocol + '//' + window.location.host;
+			var r = window.location.protocol + '//' + window.location.host + window.location.pathname.replace(/\/[^\/]*$/, '');
 			r += '/api/channel/' + this.channelId + '/watch.' + d.ext;
 			var q = Object.toQueryString(d);
 

--- a/web/page/program/watch.js
+++ b/web/page/program/watch.js
@@ -148,10 +148,12 @@ P = Class.create(P, {
 						saveSettings(d);
 
 						if (program._isRecording) {
-							d.prefix = window.location.protocol + '//' + window.location.host + '/api/recording/' + program.id + '/';
+							d.prefix = window.location.protocol + '//' + window.location.host;
+							d.prefix += window.location.pathname.replace(/\/[^\/]*$/, '') + '/api/recording/' + program.id + '/';
 							window.open('./api/recording/' + program.id + '/watch.xspf?' + Object.toQueryString(d));
 						} else {
-							d.prefix = window.location.protocol + '//' + window.location.host + '/api/recorded/' + program.id + '/';
+							d.prefix = window.location.protocol + '//' + window.location.host;
+							d.prefix += window.location.pathname.replace(/\/[^\/]*$/, '') + '/api/recorded/' + program.id + '/';
 							window.open('./api/recorded/' + program.id + '/watch.xspf?' + Object.toQueryString(d));
 						}
 					}.bind(this)
@@ -493,7 +495,7 @@ P = Class.create(P, {
 
 		var getRequestURI = function() {
 
-			var r = window.location.protocol + '//' + window.location.host;
+			var r = window.location.protocol + '//' + window.location.host + window.location.pathname.replace(/\/[^\/]*$/, '');
 			r += '/api/' + (!!p._isRecording ? 'recording' : 'recorded') + '/' + p.id + '/watch.' + d.ext;
 			var q = Object.toQueryString(d);
 


### PR DESCRIPTION
#247 
リバースプロキシのサブディレクトリで運用する場合、watch.jsがAPIにサブディレクトリを渡さないため、再生が機能しませんでした。
サブディレクトリを渡すようにしました。