### PR TITLE
アニメのtitleから「」に囲まれたsubTitleを除去

### DIFF
--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -397,7 +397,8 @@ function convertPrograms(p, ch) {
 			.replace(/[「（#＃♯第]+[0-9０-９零一壱壹弌二弐貮貳三参參弎四肆五伍六陸七柒漆八捌九玖十拾廿卄]+[話回」）]*/g, '');
 		
 		if (c.category[1]._ === 'anime') {
-			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1');
+			title = title.replace(/(?:TV|ＴＶ)?アニメ「([^「」]+)」/g, '$1')
+				.replace(/([^場版])「.+」/g, '$1');
 		}
 		
 		title = title.trim();


### PR DESCRIPTION
category: animeの番組のtitleに含まれる「」で囲まれた文字列(subTitle)を除去します。

従来のfullTitle => title:
`プリパラ　＃87「語尾の果て」【字】` => `プリパラ 「語尾の果て」`

修正後のfullTitle => title:
`プリパラ　＃87「語尾の果て」【字】` => `プリパラ`

`劇場版「空の境界」`, category: dramaの`ドラマ「女くどき飯」` などはそのままです。

Reference:
https://github.com/kanreisa/Chinachu/issues/28 https://github.com/kanreisa/Chinachu/issues/134 https://github.com/kanreisa/Chinachu/pull/264