### PR TITLE
Add Tweeter function

### DIFF
--- a/app-operator.js
+++ b/app-operator.js
@@ -355,6 +355,21 @@ function doRecord(program) {
 				util.log('SPAWN: ' + config.recordedCommand + ' (pid=' + postProcess.pid + ')');
 			}
 			
+                	// Tweeter (Experimental)
+                	if (tweeter && config.operTweeterFormat.end) {
+                	        tweeterUpdater(
+                	                config.operTweeterFormat.end
+						.replace('<id>', program.id)
+						.replace('<type>', program.channel.type)
+						.replace('<channel>', ((program.channel.type === 'CS') ? program.channel.sid : program.channel.channel))
+						.replace('<title>',   program.title)
+						.replace('<channelname>', program.channel.name)
+						.replace('<date>', dateFormat(new Date(program.start), "mm/dd"))
+						.replace('<starttime>', dateFormat(new Date(program.start), "h:MM"))
+						.replace('<endtime>', dateFormat(new Date(program.end), "h:MM"))
+                        	);
+                	}
+			
 			finalize = null;
 		};
 		// 録画プロセス終了時処理
@@ -373,6 +388,10 @@ function doRecord(program) {
 					.replace('<type>', program.channel.type)
 					.replace('<channel>', ((program.channel.type === 'CS') ? program.channel.sid : program.channel.channel))
 					.replace('<title>',   program.title)
+					.replace('<channelname>', program.channel.name)
+					.replace('<date>', dateFormat(new Date(program.start), "mm/dd"))
+					.replace('<starttime>', dateFormat(new Date(program.start), "h:MM"))
+					.replace('<endtime>', dateFormat(new Date(program.end), "h:MM"))
 			);
 		}
 	}, 0, 'RECWAIT: ' + tuner.name);
@@ -407,6 +426,10 @@ function prepRecord(program) {
 				.replace('<type>', program.channel.type)
 				.replace('<channel>', ((program.channel.type === 'CS') ? program.channel.sid : program.channel.channel))
 				.replace('<title>',   program.title)
+				.replace('<channelname>', program.channel.name)
+				.replace('<date>', dateFormat(new Date(program.start), "mm/dd"))
+				.replace('<starttime>', dateFormat(new Date(program.start), "h:MM"))
+				.replace('<endtime>', dateFormat(new Date(program.end), "h:MM"))
 		);
 	}
 }


### PR DESCRIPTION
Tweeterの機能追加です。  
文面作成時のタグを追加しました。
- 録画しているチャンネル名(```<channelname>```)
- 日付(```<date>```)
- 開始時刻(```<starttime>```)
- 終了時刻(```<endtime>```)  

録画終了時にツイートができるようにしました
- config.json内のoperTweeterFormat内に```"end" : "string"```と記述

よろしくお願いします。取り込んで頂けるとうれしいです。