### PR TITLE
tuners.command の <type> を channel.type に置換

### DIFF
--- a/app-operator.js
+++ b/app-operator.js
@@ -270,6 +270,7 @@ function doRecord(program) {
 	// 録画コマンド
 	recCmd = tuner.command;
 	recCmd = recCmd.replace('<channel>', program.channel.channel);
+	recCmd = recCmd.replace('<type>', program.channel.type);
 	if (program['1seg'] === true) {
 		recCmd = recCmd.replace(' --b25', '');
 		recCmd = recCmd.replace('<sid>', '1seg');

--- a/app-scheduler.js
+++ b/app-scheduler.js
@@ -980,6 +980,7 @@ function getEpg() {
 			};
 			
 			var recCmd = tuner.command.replace('<channel>', channel.channel);
+			recCmd = recCmd.replace('<type>', channel.type);
 			
 			// recpt1用
 			recCmd = recCmd.replace(' --b25', '').replace(' --strip', '').replace('<sid>', 'epg');


### PR DESCRIPTION
Rivarunにchを渡す際、typeタグにてBS/CSを動的に変更できると
設定が簡潔となりますのでご検討願います。

### Mirakurun + Rivarun 設定例
```json
  "tuners": [
    {
      "name"        : "PT3-S0-BS",
      "isScrambling": false,
      "types"       : [ "BS","CS" ],
      "command"     : "/usr/local/bin/rivarun --mirakurun 127.0.0.1:8888 --b25 --priority 1 --sid <sid> --ch <type>/<channel> - -",
      "noEpg"       : false
    },
    {
      "name"        : "PT3-S1-BS",
      "isScrambling": false,
      "types"       : [ "BS","CS" ],
      "command"     : "/usr/local/bin/rivarun --mirakurun 127.0.0.1:8888 --b25 --priority 1 --sid <sid> --ch <type>/<channel> - -",
      "noEpg"       : true
    },
    {
      "name"        : "PT3-T0",
      "isScrambling": false,
      "types"       : [ "GR" ],
      "command"     : "/usr/local/bin/rivarun --mirakurun 127.0.0.1:8888 --b25 --priority 1 --sid <sid> --ch <type>/<channel> - -",
      "noEpg"       : false
    },
    {
      "name"        : "PT3-T1",
      "isScrambling": false,
      "types"       : [ "GR" ],
      "command"     : "/usr/local/bin/rivarun --mirakurun 127.0.0.1:8888 --b25 --priority 1 --sid <sid> --ch <type>/<channel> - -",
      "noEpg"       : true
    }
  ], 
  "channels": [
    { "type": "BS", "channel": "BS23_2", "sid": "258", "name": "D-Life" },
    { "type": "CS", "channel": "CS12", "sid": "258", "name": "MUSIC ON! TV" }
  ]
```