### PR TITLE
mDNS network advertisement support (master)

### DIFF
--- a/app-wui.js
+++ b/app-wui.js
@@ -40,6 +40,7 @@ var chinachu      = require('chinachu-common');
 var S             = require('string');
 var geoip         = require('geoip-lite');
 var UPnPServer    = require('chinachu-upnp-server');
+var mdns          = require('mdns-js');
 
 // Directory Checking
 if (!fs.existsSync('./data/') || !fs.existsSync('./log/') || !fs.existsSync('./web/')) {
@@ -50,7 +51,12 @@ if (!fs.existsSync('./data/') || !fs.existsSync('./log/') || !fs.existsSync('./w
 // SIGQUIT
 process.on('SIGQUIT', function () {
 	setTimeout(function () {
-		process.exit(0);
+		serverMdns && serverMdns.stop()
+		openServerMdns && openServerMdns.stop()
+		// Wait stopping mDNS service
+		setTimeout(function() {
+			process.exit(0);
+		}, 1000);
 	}, 0);
 });
 
@@ -68,6 +74,7 @@ process.on('uncaughtException', function (err) {
 // etc.
 var timer = {};
 var emptyFunction = function () {};
+var serverMdns, openServerMdns;
 var status = {
 	connectedCount: 0,
 	feature: {
@@ -150,6 +157,17 @@ if (tlsEnabled) {
 server.timeout = 240000;
 server.listen(config.wuiPort || 10772, config.wuiHost || '::', function () {
 	util.log((tlsEnabled ? 'HTTPS' : 'HTTP') + ' Server Listening on ' + util.inspect(server.address()));
+	// Start mDNS advertisement
+	serverMdns = mdns.createAdvertisement(mdns.tcp(tlsEnabled ? '_https' : '_http'), config.wuiPort || 10772, {
+		name: 'Chinachu',
+		txt: {
+			txtvers: '1',
+			'Version': 'beta',
+			'Password': basicAuthEnabled
+		}
+	});
+	serverMdns.start();
+	util.log((tlsEnabled ? 'HTTPS' : 'HTTP') + ' Server mDNS advertising started.');
 });
 
 // EXPERIMENTAL: Open Server for Access from LAN.
@@ -159,6 +177,17 @@ if (openServerEnabled) {
 	dns.lookup(os.hostname(), function (err, hostIp) {
 		openServer.listen(config.wuiOpenPort || 20772, config.wuiOpenHost || hostIp, function () {
 			util.log('HTTP Open Server Listening on ' + util.inspect(openServer.address()));
+			// Start mDNS advertisement
+			openServerMdns = mdns.createAdvertisement(mdns.tcp('_http'), config.wuiOpenPort || 20772, {
+				name: 'Chinachu Open Server',
+				txt: {
+					txtvers: '1',
+					'Version': 'beta',
+					'Password': false
+				}
+			});
+			openServerMdns.start();
+			util.log('HTTP Open Server mDNS advertising started.');
 		});
 	});
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "geoip-lite": "^1.1.6",
     "hoard": "~0.1.5",
     "http-auth": "^2.2.8",
+    "mdns-js": "^0.5.0",
     "mkdirp": "~0.3.5",
     "mtwitter": "~1.5.2",
     "opts": "~1.2.2",


### PR DESCRIPTION
Chinachuクライアントを作るにあたって、LAN内のChinachuが簡単に見つかるとUXが向上するのでつけました。
mDNSの追加にあたってコードの変更点は多くなく、Chinachu自体の動作には影響の無い機能拡張です。